### PR TITLE
Use replace from Data.Text instead of inplace

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -85,12 +85,13 @@ determineTemplatesToGenerate settings =
         nativeTemplates = [nativeComponentTemplate, stylesTemplate, indexTemplate]
 
 {--| Generates the component's path, writes the file, and replaces the placeholder text with the template name. --}
-generateComponent :: Settings -> Template -> IO ()
+generateComponent :: Settings -> Template -> IO OSFilePath
 generateComponent settings template =
-  writeTemplateFile (componentPath </> fromText sanitizedFileName) (contents template) >>= replacePlaceholder
+  writeTemplateFile (componentPath </> fromText sanitizedFileName) sanitizedTemplate
   where componentPath = (settings ^. sComponentDir) </> fromText componentName
         componentName = settings ^. sComponentName
-        sanitizedFileName = replace "COMPONENT" componentName (filename template)
+        sanitizedFileName = replacePlaceholder (filename template)
+        sanitizedTemplate = replacePlaceholder (contents template)
         replacePlaceholder = replacePlaceholderText componentName
 
 
@@ -101,10 +102,9 @@ writeTemplateFile dest src = do
   writeTextFile dest src
   return dest
 
-{--| Replaces the text "COMPONENT" in the template file with the component name. --}
-replacePlaceholderText :: MonadIO io => Text -> OSFilePath -> io()
-replacePlaceholderText componentName =
-  inplace ("COMPONENT" *> pure componentName)
+replacePlaceholderText :: Text -> Text -> Text
+replacePlaceholderText =
+  replace "COMPONENT"
 
 {--| Testing --}
 instance Arbitrary Settings where

--- a/src/Templates.hs
+++ b/src/Templates.hs
@@ -8,7 +8,7 @@ import           Data.Text      (Text)
 data Template = Template
   { filename :: Text
   , contents :: Text
-  }
+  } deriving (Show)
 
 componentTemplate :: Template
 componentTemplate = Template "COMPONENT.js" [s|


### PR DESCRIPTION
Unnecessary to write the file with the placeholder text then run inplace
on it to open it, create a tmp file with the replaced text, then replace
the original file. More efficient to just replace the placeholder text
prior to writing the file.