### PR TITLE
Add test for component directory generation

### DIFF
--- a/componentGenerator.cabal
+++ b/componentGenerator.cabal
@@ -18,12 +18,17 @@ cabal-version:       >=1.10
 executable generate-component
   main-is:             Main.hs
   other-modules:       Templates
+                     , TestMain
   -- other-extensions:    
   build-depends:       base >=4.9 && <4.10
+                     , lens
                      , optparse-applicative >= 0.12
                      , text
                      , string-qq
                      , system-filepath
                      , turtle
+                     , QuickCheck
+                     , quickcheck-instances
   hs-source-dirs:      src
+                     , test
   default-language:    Haskell2010

--- a/test/TestMain.hs
+++ b/test/TestMain.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module TestMain where
+
+import           Control.Lens              hiding (pre, (<.>))
+import           Data.Text                 (length)
+import           Filesystem.Path.CurrentOS (fromText, valid, (</>), (<.>))
+import           Prelude                   hiding (length)
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic
+import           Turtle.Prelude            (testdir, testfile)
+
+import           Main
+
+runMakesFileProp :: IO ()
+runMakesFileProp = quickCheck prop_makesFiles
+
+prop_makesFiles :: Settings -> Property
+prop_makesFiles settings@(Settings componentName componentPath _container _native) = monadicIO $ do
+  let componentNamePath = fromText componentName
+  let tmpDir = "/tmp" </> (settings ^. sComponentDir)
+  let tmpSettings = sComponentDir .~  tmpDir $ settings
+  let componentDir = tmpDir </> componentNamePath
+
+  pre (length componentName > 1 && valid componentPath && valid componentNamePath)
+  run $ generateDesiredTemplates tmpSettings
+
+  dirExists <- testdir componentDir
+  filesExist <- mapM testfile $ (componentDir </>) <$> [componentNamePath <.> "js", "index.js"]
+
+  assert dirExists
+  assert $ and filesExist


### PR DESCRIPTION
Adds monadic quickcheck test for component directory creation.

Rewrites Main to use lenses for getting fields from settings; this is to
facilitate setting the component directory with a `/tmp/` prefix so that
tests are written there.

TODO: Refactor test. Add testing for whether container/native files are
generated when the settings are appropriate.