### PR TITLE
Refactor application and add test runner + CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,141 @@
+# Default config from stack documentation
+
+# Use new container infrastructure to enable caching
+sudo: false
+
+# Choose a lightweight base image; we provide our own build tools.
+language: c
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.ghc
+  - $HOME/.cabal
+  - $HOME/.stack
+
+# The different configurations we want to test. We have BUILD=cabal which uses
+# cabal-install, and BUILD=stack which uses Stack. More documentation on each
+# of those below.
+#
+# We set the compiler values here to tell Travis to use a different
+# cache file per set of arguments.
+#
+# If you need to have different apt packages for each combination in the
+# matrix, you can use a line such as:
+#     addons: {apt: {packages: [libfcgi-dev,libgmp-dev]}}
+matrix:
+  include:
+  # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
+  # https://github.com/hvr/multi-ghc-travis
+  - env: BUILD=cabal GHCVER=8.0.1 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.0.1"
+    addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+
+  # Build with the newest GHC and cabal-install. This is an accepted failure,
+  # see below.
+  - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC HEAD"
+    addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+
+  # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
+  # variable, such as using --stack-yaml to point to a different file.
+  - env: BUILD=stack ARGS=""
+    compiler: ": #stack default"
+    addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
+
+  # Nightly builds are allowed to fail
+  - env: BUILD=stack ARGS="--resolver nightly"
+    compiler: ": #stack nightly"
+    addons: {apt: {packages: [libgmp,libgmp-dev]}}
+
+  # Build on OS X in addition to Linux
+  - env: BUILD=stack ARGS=""
+    compiler: ": #stack default osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver nightly"
+    compiler: ": #stack nightly osx"
+    os: osx
+
+  allow_failures:
+  - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
+  - env: BUILD=stack ARGS="--resolver nightly"
+
+before_install:
+# Using compiler above sets CC to an invalid value, so unset it
+- unset CC
+
+# We want to always allow newer versions of packages when building on GHC HEAD
+- CABALARGS=""
+- if [ "x$GHCVER" = "xhead" ]; then CABALARGS=--allow-newer; fi
+
+# Download and unpack the stack executable
+- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
+- mkdir -p ~/.local/bin
+- |
+  if [ `uname` = "Darwin" ]
+  then
+    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+  else
+    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  fi
+
+  # Use the more reliable S3 mirror of Hackage
+  mkdir -p $HOME/.cabal
+  echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
+  echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
+
+  if [ "$CABALVER" != "1.16" ]
+  then
+    echo 'jobs: $ncpus' >> $HOME/.cabal/config
+  fi
+
+# Get the list of packages from the stack.yaml file
+- PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
+
+install:
+- echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+- if [ -f configure.ac ]; then autoreconf -i; fi
+- |
+  set -ex
+  case "$BUILD" in
+    stack)
+      stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+      ;;
+    cabal)
+      cabal --version
+      travis_retry cabal update
+      cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      ;;
+  esac
+  set +ex
+
+script:
+- |
+  set -ex
+  case "$BUILD" in
+    stack)
+      stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps
+      ;;
+    cabal)
+      cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+
+      ORIGDIR=$(pwd)
+      for dir in $PACKAGES
+      do
+        cd $dir
+        cabal check || [ "$CABALVER" == "1.16" ]
+        cabal sdist
+        PKGVER=$(cabal info . | awk '{print $2;exit}')
+        SRC_TGZ=$PKGVER.tar.gz
+        cd dist
+        tar zxfv "$SRC_TGZ"
+        cd "$PKGVER"
+        cabal configure --enable-tests
+        cabal build
+        cabal test
+        cd $ORIGDIR
+      done
+      ;;
+  esac
+  set +ex

--- a/README.org
+++ b/README.org
@@ -85,3 +85,8 @@
 *** Note
    - DIR: an optional directory under which to create the component; defaults to ~./app/components/~
    - ~-c~: a flag that, if present, additionally generates a redux container component
+** Testing
+*** To run the tests:
+    #+BEGIN_SRC sh
+    stack test
+    #+END_SRC

--- a/componentGenerator.cabal
+++ b/componentGenerator.cabal
@@ -3,8 +3,8 @@
 
 name:                componentGenerator
 version:             0.2.0.0
-synopsis:            Generate scaffolds for react native components.
--- description:         
+synopsis:            Generate scaffolds for React components.
+description:         A generator for React and React Rative components.
 license:             BSD3
 license-file:        LICENSE
 author:              Travis Poulsen
@@ -14,21 +14,50 @@ category:            Development
 build-type:          Simple
 extra-source-files:  ChangeLog.md
 cabal-version:       >=1.10
+source-repository head
+  type:              git
+  location:          https://github.com/tpoulsen/generate-component
 
 executable generate-component
   main-is:             Main.hs
-  other-modules:       Templates
-                     , TestMain
+  other-modules:       ComponentGenerator
+                     , Parser
+                     , Templates
+                     , Types
   -- other-extensions:    
   build-depends:       base >=4.9 && <4.10
+                     , QuickCheck
                      , lens
                      , optparse-applicative >= 0.12
-                     , text
+                     , quickcheck-instances
                      , string-qq
                      , system-filepath
+                     , tasty
+                     , tasty-quickcheck
+                     , text
                      , turtle
-                     , QuickCheck
-                     , quickcheck-instances
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+
+test-suite test
+  default-language:    Haskell2010
+  type:                exitcode-stdio-1.0
+  Buildable:           True
   hs-source-dirs:      src
                      , test
-  default-language:    Haskell2010
+  main-is:             Spec.hs
+  other-modules:       ComponentGenerator
+                     , Parser
+                     , Templates
+                     , Types
+  build-depends:       base >= 4 && < 5
+                     , QuickCheck
+                     , lens
+                     , optparse-applicative >= 0.12
+                     , quickcheck-instances
+                     , string-qq
+                     , system-filepath
+                     , tasty >= 0.7
+                     , tasty-quickcheck
+                     , text
+                     , turtle

--- a/src/ComponentGenerator.hs
+++ b/src/ComponentGenerator.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-| A generator for React Native components.
+ -| Travis Poulsen - 2016
+-}
+module ComponentGenerator where
+
+import           Control.Lens
+import           Data.Text                 (replace)
+import           Filesystem.Path.CurrentOS (fromText, (</>))
+import           Parser
+import           Templates
+import           Turtle                    (Text)
+import           Turtle.Format
+import           Turtle.Options            (options)
+import           Turtle.Prelude
+import           Types
+
+{--| If the component doesn't already exist, creates component directory and requisite files. --}
+generateDesiredTemplates :: Settings -> IO ()
+generateDesiredTemplates settings@(Settings componentName componentPath' _container _native) = do
+  dirExists <- testdir componentPath
+  if dirExists
+    then echo "Component directory exists; exiting without action."
+    else do
+      echo $ format ("Making directory at: "%s%"") (format fp componentPath)
+      mktree componentPath
+      echo "Copying files..."
+      runGenerator $ determineTemplatesToGenerate settings
+  where componentPath = componentPath' </> componentNamePath
+        componentNamePath = fromText componentName
+        componentGenerator = generateComponent settings
+        runGenerator = mapM_ componentGenerator
+
+{--| Determines which templates to create based on command line arguments. --}
+determineTemplatesToGenerate :: Settings -> [Template]
+determineTemplatesToGenerate settings =
+  case makeReactNative of
+    True  | makeContainer -> containerTemplate : nativeTemplates
+          | otherwise     -> nativeTemplates
+    False | makeContainer -> containerTemplate : reactTemplates
+          | otherwise     -> reactTemplates
+  where makeReactNative = settings ^. sReactNative
+        makeContainer   = settings ^. sMakeContainer
+        reactTemplates  = [componentTemplate, indexTemplate]
+        nativeTemplates = [nativeComponentTemplate, stylesTemplate, indexTemplate]
+
+{--| Generates the component's path, writes the file, and replaces the placeholder text with the template name. --}
+generateComponent :: Settings -> Template -> IO OSFilePath
+generateComponent settings template =
+  writeTemplateFile (componentPath </> fromText sanitizedFileName) sanitizedTemplate
+  where componentPath = (settings ^. sComponentDir) </> fromText componentName
+        componentName = settings ^. sComponentName
+        sanitizedFileName = replacePlaceholder (filename template)
+        sanitizedTemplate = replacePlaceholder (contents template)
+        replacePlaceholder = replacePlaceholderText componentName
+
+
+{--| Writes a file with the template's contents to a file named after the template's name. --}
+writeTemplateFile :: OSFilePath -> Text -> IO OSFilePath
+writeTemplateFile dest src = do
+  echo $ format ("Writing\t"%s%"...") (format fp dest)
+  writeTextFile dest src
+  return dest
+
+replacePlaceholderText :: Text -> Text -> Text
+replacePlaceholderText =
+  replace "COMPONENT"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,34 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
 {-| A generator for React Native components.
  -| Travis Poulsen - 2016
 -}
 module Main where
 
-import           Control.Lens
-import           Control.Monad.IO.Class    (MonadIO)
-import           Data.Char                 (chr)
-import           Data.Monoid               ((<>))
-import           Data.Text                 (pack, replace)
-import           Filesystem.Path.CurrentOS (FilePath, fromText, valid, (</>))
-import           Options.Applicative
-import           Templates
-import           Test.QuickCheck           (Gen, choose, listOf1, oneof, suchThat)
-import           Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
-import           Test.QuickCheck.Instances ()
-import           Turtle                    (Text)
-import           Turtle.Format
-import           Turtle.Options            (options)
+import           ComponentGenerator
+import           Parser
+import           Turtle.Options     (options)
 import           Turtle.Prelude
-
-type OSFilePath = Filesystem.Path.CurrentOS.FilePath
-data Settings = Settings
-  { _sComponentName :: Text
-  , _sComponentDir  :: OSFilePath
-  , _sMakeContainer :: Bool
-  , _sReactNative   :: Bool
-  } deriving (Eq, Show, Ord)
-makeLenses ''Settings
 
 main :: IO ()
 main = do
@@ -36,95 +15,4 @@ main = do
   generateDesiredTemplates settings
   echo "Done"
 
-{--| Command line argument parser --}
-parser :: Parser Settings
-parser = Settings <$>
-      fmap pack (Options.Applicative.argument str (metavar "NAME"))
-      <*> fmap (fromText . pack) (strOption
-        ( long "component-directory"
-       <> short 'd'
-       <> metavar "DIR"
-       <> value "./app/components"
-       <> help "Directory to add the component" ))
-      <*> switch
-        ( long "make-container"
-       <> short 'c'
-       <> help "Create a container component" )
-      <*> switch
-        ( long "react-native"
-       <> short 'n'
-       <> help "Create a React Native component" )
 
-{--| If the component doesn't already exist, creates component directory and requisite files. --}
-generateDesiredTemplates :: Settings -> IO ()
-generateDesiredTemplates settings@(Settings componentName componentPath' _container _native) = do
-  dirExists <- testdir componentPath
-  if dirExists
-    then echo "Component directory exists; exiting without action."
-    else do
-      echo $ format ("Making directory at: "%s%"") (format fp componentPath)
-      mktree componentPath
-      echo "Copying files..."
-      runGenerator $ determineTemplatesToGenerate settings
-  where componentPath = componentPath' </> componentNamePath
-        componentNamePath = fromText componentName
-        componentGenerator = generateComponent settings
-        runGenerator = mapM_ componentGenerator
-
-{--| Determines which templates to create based on command line arguments. --}
-determineTemplatesToGenerate :: Settings -> [Template]
-determineTemplatesToGenerate settings =
-  case makeReactNative of
-    True  | makeContainer -> containerTemplate : nativeTemplates
-          | otherwise     -> nativeTemplates
-    False | makeContainer -> containerTemplate : reactTemplates
-          | otherwise     -> reactTemplates
-  where makeReactNative = settings ^. sReactNative
-        makeContainer   = settings ^. sMakeContainer
-        reactTemplates  = [componentTemplate, indexTemplate]
-        nativeTemplates = [nativeComponentTemplate, stylesTemplate, indexTemplate]
-
-{--| Generates the component's path, writes the file, and replaces the placeholder text with the template name. --}
-generateComponent :: Settings -> Template -> IO OSFilePath
-generateComponent settings template =
-  writeTemplateFile (componentPath </> fromText sanitizedFileName) sanitizedTemplate
-  where componentPath = (settings ^. sComponentDir) </> fromText componentName
-        componentName = settings ^. sComponentName
-        sanitizedFileName = replacePlaceholder (filename template)
-        sanitizedTemplate = replacePlaceholder (contents template)
-        replacePlaceholder = replacePlaceholderText componentName
-
-
-{--| Writes a file with the template's contents to a file named after the template's name. --}
-writeTemplateFile :: OSFilePath -> Text -> IO OSFilePath
-writeTemplateFile dest src = do
-  echo $ format ("Writing\t"%s%"...") (format fp dest)
-  writeTextFile dest src
-  return dest
-
-replacePlaceholderText :: Text -> Text -> Text
-replacePlaceholderText =
-  replace "COMPONENT"
-
-{--| Testing --}
-instance Arbitrary Settings where
-  arbitrary = Settings <$>
-        genComponentName
-    <*> genFilePath
-    <*> arbitrary
-    <*> arbitrary
-
-{--| Generate a filepath using characters 0-9 and A-z --}
-genFilePath :: Gen OSFilePath
-genFilePath = arbitraryFilePath `suchThat` valid
-  where arbitraryFilePath = fromText <$> genText
-
-genComponentName :: Gen Text
-genComponentName = genText `suchThat` (valid . fromText)
-
-genText :: Gen Text
-genText = pack <$> listOf1 validChars
-  where validChars = chr <$> oneof [genNums, genLowerCase, genUpperCase]
-        genNums = choose (48, 57)
-        genLowerCase = choose (97, 122)
-        genUpperCase = choose (65, 90)

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Parser where
+
+import           Data.Text                 (pack)
+import           Filesystem.Path.CurrentOS (fromText)
+import           Options.Applicative
+import           Types
+
+{--| Command line argument parser --}
+parser :: Parser Settings
+parser = Settings <$>
+      fmap pack (Options.Applicative.argument str (metavar "NAME"))
+      <*> fmap (fromText . pack) (strOption
+        ( long "component-directory"
+       <> short 'd'
+       <> metavar "DIR"
+       <> value "./app/components"
+       <> help "Directory to add the component" ))
+      <*> switch
+        ( long "make-container"
+       <> short 'c'
+       <> help "Create a container component" )
+      <*> switch
+        ( long "react-native"
+       <> short 'n'
+       <> help "Create a React Native component" )

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Types where
+
+import           Control.Lens
+import           Data.Char                 (chr)
+import           Data.Text
+import           Filesystem.Path.CurrentOS (FilePath, fromText, valid)
+import           Test.QuickCheck           (Gen, choose, listOf1, oneof, suchThat)
+import           Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
+import           Test.QuickCheck.Instances ()
+
+type OSFilePath = Filesystem.Path.CurrentOS.FilePath
+data Settings = Settings
+  { _sComponentName :: Text
+  , _sComponentDir  :: OSFilePath
+  , _sMakeContainer :: Bool
+  , _sReactNative   :: Bool
+  } deriving (Eq, Show, Ord)
+makeLenses ''Settings
+
+{--| Testing --}
+instance Arbitrary Settings where
+  arbitrary = Settings <$>
+        genComponentName
+    <*> genFilePath
+    <*> arbitrary
+    <*> arbitrary
+
+{--| Generate a filepath using characters 0-9 and A-z --}
+genFilePath :: Gen OSFilePath
+genFilePath = arbitraryFilePath `suchThat` valid
+  where arbitraryFilePath = fromText <$> genText
+
+genComponentName :: Gen Text
+genComponentName = genText `suchThat` (valid . fromText)
+
+genText :: Gen Text
+genText = pack <$> listOf1 validChars
+  where validChars = chr <$> oneof [genNums, genLowerCase, genUpperCase]
+        genNums = choose (48, 57)
+        genLowerCase = choose (97, 122)
+        genUpperCase = choose (65, 90)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,16 +1,32 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module TestMain where
+module Main where
 
 import           Control.Lens              hiding (pre, (<.>))
 import           Data.Text                 (length)
-import           Filesystem.Path.CurrentOS (fromText, valid, (</>), (<.>))
+import           Filesystem.Path.CurrentOS (fromText, valid, (<.>), (</>))
 import           Prelude                   hiding (length)
 import           Test.QuickCheck
 import           Test.QuickCheck.Monadic
+import           Test.Tasty
+import           Test.Tasty.QuickCheck     as QC
 import           Turtle.Prelude            (testdir, testfile)
 
-import           Main
+import           ComponentGenerator
+import           Types
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Tests" [properties]
+
+properties :: TestTree
+properties = testGroup "Properties" [qcProps]
+
+qcProps = testGroup "(checked by QuickCheck)"
+  [ QC.testProperty "files are created" prop_makesFiles
+  ]
 
 runMakesFileProp :: IO ()
 runMakesFileProp = quickCheck prop_makesFiles


### PR DESCRIPTION
Breaks components in main file out into dedicated Parser.hs, Types.hs,
and ComponentGenerator.hs files. Main is now just a thin wrapper that
runs the command line parser and calls the functions in
ComponentGenerator.

Pulling ComponentGenerator functionality into its own file allows
running tests with `stack test`; tasty is used as the test runner.

Closes #14