### PR TITLE
Import/export container component in index when one is generated

### DIFF
--- a/componentGenerator.cabal
+++ b/componentGenerator.cabal
@@ -35,7 +35,7 @@ executable generate-component
                      , tasty
                      , tasty-quickcheck
                      , text
-                     , turtle
+                     , turtle == 1.2.8
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -60,4 +60,4 @@ test-suite test
                      , tasty >= 0.7
                      , tasty-quickcheck
                      , text
-                     , turtle
+                     , turtle == 1.2.8

--- a/src/ComponentGenerator.hs
+++ b/src/ComponentGenerator.hs
@@ -7,11 +7,9 @@ module ComponentGenerator where
 import           Control.Lens
 import           Data.Text                 (replace)
 import           Filesystem.Path.CurrentOS (fromText, (</>))
-import           Parser
 import           Templates
 import           Turtle                    (Text)
 import           Turtle.Format
-import           Turtle.Options            (options)
 import           Turtle.Prelude
 import           Types
 
@@ -35,14 +33,14 @@ generateDesiredTemplates settings@(Settings componentName componentPath' _contai
 determineTemplatesToGenerate :: Settings -> [Template]
 determineTemplatesToGenerate settings =
   case makeReactNative of
-    True  | makeContainer -> containerTemplate : nativeTemplates
-          | otherwise     -> nativeTemplates
-    False | makeContainer -> containerTemplate : reactTemplates
-          | otherwise     -> reactTemplates
+    True  | makeContainer -> containerTemplate : containerIndexTemplate : nativeTemplates
+          | otherwise     -> indexTemplate : nativeTemplates
+    False | makeContainer -> containerTemplate : containerIndexTemplate : reactTemplates
+          | otherwise     -> indexTemplate : reactTemplates
   where makeReactNative = settings ^. sReactNative
         makeContainer   = settings ^. sMakeContainer
-        reactTemplates  = [componentTemplate, indexTemplate]
-        nativeTemplates = [nativeComponentTemplate, stylesTemplate, indexTemplate]
+        reactTemplates  = [componentTemplate]
+        nativeTemplates = [nativeComponentTemplate, stylesTemplate]
 
 {--| Generates the component's path, writes the file, and replaces the placeholder text with the template name. --}
 generateComponent :: Settings -> Template -> IO OSFilePath

--- a/src/Templates.hs
+++ b/src/Templates.hs
@@ -115,3 +115,10 @@ import COMPONENT from './COMPONENT';
 
 export default COMPONENT;
 |]
+
+containerIndexTemplate :: Template
+containerIndexTemplate = Template "index.js" [s|
+import COMPONENTContainer from './COMPONENTContainer';
+
+export default COMPONENTContainer;
+|]


### PR DESCRIPTION
When generating a container component, it is the container component
that should be imported and exported in the index, not the base
component.

There is probably a nicer way to handle this, and this is an area to
refactor in the future.

Closes #11