### PR TITLE
Add generators for ES6 class, functional, or createClass components

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,20 +18,38 @@
      Copied executables to $HOME/.local/bin:
      - generate-component
 
+     generate-component -h
+     Flexible generator for React/React-Native components
 
-     ~/.local/bin/generate-component -h
-     Component generator
-
-     Usage: generate-component NAME [-d|--component-directory DIR]
-                               [-c|--make-container] [-n|--react-native]
+     Usage: generate-component COMMAND
+     Generate React/React-Native components
 
      Available options:
-       -h,--help                Show this help text
-       -d,--component-directory DIR
-                               Directory to add the component
-       -c,--make-container      Create a container component
-       -n,--react-native        Create a React Native component
+     -h,--help                Show this help text
+
+     Available commands:
+     init                     Create a config file
+     gen                      Generate a component
    #+END_SRC
+
+** Commands
+   ~generate-component~ has two subcommands:
+     + ~init~
+     + ~gen~
+*** ~init~
+    Initializes ~generate-component~ with a config file in the current directory. The config file specifies defaults such as project type, default component directory, and the default type of components to generate.
+*** ~gen~
+    Generates a component:
+    #+BEGIN_SRC sh
+      generate-component gen -h
+
+      Usage: generate-component gen NAME [-d|--component-directory DIR]
+                                    [-r|--redux-container] [-n|--react-native]
+                                    [-t|--component-type ARG]
+        Generate a component
+
+    #+END_SRC
+    Command line arguments supersede config file settings.
 
 *** Generating a React component:
    #+BEGIN_SRC sh
@@ -85,7 +103,7 @@
    #+END_SRC
 *** Note
    - DIR: an optional directory under which to create the component; defaults to ~./app/components/~
-   - ~-c~: a flag that, if present, additionally generates a redux container component
+   - ~-r~: a flag that, if present, additionally generates a redux container component
 ** Testing
 *** To run the tests:
     #+BEGIN_SRC sh

--- a/componentGenerator.cabal
+++ b/componentGenerator.cabal
@@ -26,6 +26,8 @@ executable generate-component
                      , Templates
                      , Templates.Config
                      , Templates.Components
+                     , Templates.Components.React
+                     , Templates.Components.ReactNative
                      , Templates.Containers
                      , Templates.Styles
                      , Types
@@ -59,6 +61,8 @@ test-suite test
                      , Templates
                      , Templates.Config
                      , Templates.Components
+                     , Templates.Components.React
+                     , Templates.Components.ReactNative
                      , Templates.Containers
                      , Templates.Styles
                      , Types

--- a/src/ComponentGenerator.hs
+++ b/src/ComponentGenerator.hs
@@ -16,7 +16,7 @@ import           Types
 
 {--| If the component doesn't already exist, creates component directory and requisite files. --}
 generateDesiredTemplates :: Settings -> IO ()
-generateDesiredTemplates settings@(Settings componentName (Just componentPath') _container _native) = do
+generateDesiredTemplates settings@(Settings componentName (Just componentPath') _container _native _type) = do
   let componentPath = componentPath' </> componentNamePath
   let settings' = settings & sComponentDir .~ Just componentPath
   let componentGenerator = generateComponent settings'
@@ -35,7 +35,7 @@ generateDesiredTemplates _ = echo "Bad component path..."
 {--| Determines which templates to create based on command line arguments. --}
 determineTemplatesToGenerate :: Settings -> [Template]
 determineTemplatesToGenerate settings =
-  templatesToGenerate (settings ^. sProjectType) (settings ^. sMakeContainer)
+  templatesToGenerate (settings ^. sProjectType) (fromJust $ settings ^. sComponentType) (settings ^. sMakeContainer)
 
 {--| Generates the component's path, writes the file, and replaces the placeholder text with the template name. --}
 generateComponent :: Settings -> Template -> IO OSFilePath

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -42,8 +42,12 @@ mergeConfig :: Either ParseException Config -> Settings -> Settings
 mergeConfig (Right c) s =
   s & sProjectType .~ (c ^. projectType)
     & sComponentDir .~ dir
+    & sComponentType .~ cType
   where
     dir = case s ^. sComponentDir of
       Nothing -> Just $ fromText $ c ^. defaultDirectory
-      Just x  -> Just x
+      Just d  -> Just d
+    cType = case s ^. sComponentType of
+      Nothing -> Just $ c ^. componentType
+      Just ct -> Just ct
 mergeConfig _ s = s

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -29,6 +29,7 @@ settingsParser = fmap Generate $ Settings <$>
         ( long "react-native"
        <> short 'n'
        <> help "Create a React Native component" )
+      <*> parseComponentType
 
 parseComponentDirectory :: Parser OSFilePath
 parseComponentDirectory =
@@ -37,6 +38,13 @@ parseComponentDirectory =
   <> short 'd'
   <> metavar "DIR"
   <> help "Directory in which to add the component. Relative to the project root." ))
+
+parseComponentType :: Parser (Maybe ComponentType)
+parseComponentType =
+  optional $ option auto
+  ( long "component-type"
+  <> short 't'
+  <> help "The type of component to generate" )
 
 opts :: ParserInfo Command
 opts = info (commandParser <**> helper)

--- a/src/Templates.hs
+++ b/src/Templates.hs
@@ -1,27 +1,29 @@
 module Templates where
 
 import           Templates.Components
+import           Templates.Components.React
+import           Templates.Components.ReactNative
 import           Templates.Containers
 import           Templates.Styles
 import           Types
 
-templatesToGenerate :: ProjectType -> Bool -> [Template]
-templatesToGenerate p container =
+templatesToGenerate :: ProjectType -> ComponentType -> Bool -> [Template]
+templatesToGenerate p c container =
   if container
     then containerTemplate : containerIndexTemplate : componentTemplates
     else indexTemplate : componentTemplates
-  where componentTemplates = pickComponentTemplates p
+  where componentTemplates = pickComponentTemplates p c
 
-pickComponentTemplates :: ProjectType -> [Template]
-pickComponentTemplates p =
+pickComponentTemplates :: ProjectType -> ComponentType -> [Template]
+pickComponentTemplates p c =
   case p of
-    ReactNative -> nativeTemplates
-    React       -> reactTemplates
+    ReactNative -> nativeTemplates c
+    React       -> reactTemplates c
 
-nativeTemplates :: [Template]
-nativeTemplates =
-  [nativeComponentTemplate, stylesTemplate]
+nativeTemplates :: ComponentType -> [Template]
+nativeTemplates c =
+  [nativeComponentTemplate c, stylesTemplate]
 
-reactTemplates :: [Template]
-reactTemplates =
-  [reactComponentTemplate]
+reactTemplates :: ComponentType -> [Template]
+reactTemplates c =
+  [reactComponentTemplate c]

--- a/src/Templates/Components.hs
+++ b/src/Templates/Components.hs
@@ -2,61 +2,12 @@
 {-# LANGUAGE QuasiQuotes       #-}
 module Templates.Components where
 
-import           Data.Text                     (Text)
 import           Text.InterpolatedString.Perl6 (q, qc)
 import           Types
 
 indexTemplate :: Template
 indexTemplate = Template "index.js" [q|
 import COMPONENT from './COMPONENT';
-
-export default COMPONENT;
-|]
-
-reactComponentTemplate :: Template
-reactComponentTemplate = Template "COMPONENT.js" [q|
-// @flow
-/*
-   NOTE: This file was auto-generated for a component
-   named "COMPONENT"; it is intended to be modified as
-   needed to be useful.
-*/
-
-import React, {PropTypes} from 'react';
-import {render} from 'react-dom';
-
-const COMPONENT = ({}) => (
-  <div>
-  </div>
-);
-
-COMPONENT.propTypes = {
-};
-
-export default COMPONENT;
-|]
-
-nativeComponentTemplate :: Template
-nativeComponentTemplate = Template "COMPONENT.js" [q|
-// @flow
-/*
-   NOTE: This file was auto-generated for a component
-   named "COMPONENT"; it is intended to be modified as
-   needed to be useful.
-*/
-
-import React, {PropTypes} from 'react';
-import {View} from 'react-native';
-
-import styles from './styles';
-
-const COMPONENT = ({}) => (
-  <View>
-  </View>
-);
-
-COMPONENT.propTypes = {
-};
 
 export default COMPONENT;
 |]

--- a/src/Templates/Components/React.hs
+++ b/src/Templates/Components/React.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+module Templates.Components.React where
+
+import           Text.InterpolatedString.Perl6 (q, qc)
+import           Types
+
+reactComponentTemplate :: ComponentType -> Template
+reactComponentTemplate cType =
+  case cType of
+    Functional  -> functionalReactComponent
+    ES6Class    -> es6ReactComponent
+    CreateClass -> createClassReactComponent
+
+functionalReactComponent :: Template
+functionalReactComponent = Template "COMPONENT.js" [q|
+// @flow
+/*
+   NOTE: This file was auto-generated for a component
+   named "COMPONENT"; it is intended to be modified as
+   needed to be useful.
+*/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {render} from 'react-dom';
+
+const COMPONENT = ({}) => (
+  <div>
+  </div>
+);
+
+COMPONENT.propTypes = {
+};
+
+export default COMPONENT;
+|]
+
+es6ReactComponent :: Template
+es6ReactComponent = Template "COMPONENT.js" [q|
+// @flow
+/*
+   NOTE: This file was auto-generated for a component
+   named "COMPONENT"; it is intended to be modified as
+   needed to be useful.
+*/
+
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {render} from 'react-dom';
+
+class COMPONENT extends Component {
+  static propTypes = {
+  };
+
+  render() {
+    return (
+      <div>
+      </div>
+    );
+  }
+}
+
+export default COMPONENT;
+|]
+
+createClassReactComponent :: Template
+createClassReactComponent = Template "COMPONENT.js" [q|
+// @flow
+/*
+   NOTE: This file was auto-generated for a component
+   named "COMPONENT"; it is intended to be modified as
+   needed to be useful.
+*/
+
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import {render} from 'react-dom';
+
+const COMPONENT = createReactClass({
+  propTypes: {
+  };
+
+  render() {
+    return (
+      <div>
+      </div>
+    );
+  }
+});
+
+export default COMPONENT;
+|]

--- a/src/Templates/Components/ReactNative.hs
+++ b/src/Templates/Components/ReactNative.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+module Templates.Components.ReactNative where
+
+import           Text.InterpolatedString.Perl6 (q, qc)
+import           Types
+
+nativeComponentTemplate :: ComponentType -> Template
+nativeComponentTemplate cType =
+  case cType of
+    Functional  -> functionalNativeComponent
+    ES6Class    -> es6NativeComponent
+    CreateClass -> createClassNativeComponent
+
+functionalNativeComponent :: Template
+functionalNativeComponent = Template "COMPONENT.js" [q|
+// @flow
+/*
+   NOTE: This file was auto-generated for a component
+   named "COMPONENT"; it is intended to be modified as
+   needed to be useful.
+*/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {View} from 'react-native';
+
+import styles from './styles';
+
+const COMPONENT = ({}) => (
+  <View>
+  </View>
+);
+
+COMPONENT.propTypes = {
+};
+
+export default COMPONENT;
+|]
+
+es6NativeComponent :: Template
+es6NativeComponent = Template "COMPONENT.js" [q|
+// @flow
+/*
+   NOTE: This file was auto-generated for a component
+   named "COMPONENT"; it is intended to be modified as
+   needed to be useful.
+*/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {View} from 'react-native';
+
+import styles from './styles';
+
+class COMPONENT extends Component {
+  static propTypes = {
+  };
+
+  render() {
+    return (
+      <View>
+      </View>
+    );
+  }
+}
+
+export default COMPONENT;
+|]
+
+createClassNativeComponent :: Template
+createClassNativeComponent = Template "COMPONENT.js" [q|
+// @flow
+/*
+   NOTE: This file was auto-generated for a component
+   named "COMPONENT"; it is intended to be modified as
+   needed to be useful.
+*/
+
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import {View} from 'react-native';
+
+const COMPONENT = createReactClass({
+  propTypes: {
+  };
+
+  render() {
+    return (
+      <View>
+      </View>
+    );
+  }
+});
+
+export default COMPONENT;
+|]

--- a/src/Templates/Config.hs
+++ b/src/Templates/Config.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE QuasiQuotes       #-}
 module Templates.Config where
 
-import           Data.Text                     (Text)
 import           Text.InterpolatedString.Perl6 (q, qc)
 import           Types
 
@@ -18,5 +17,5 @@ defaultDirectory: app/components
 
 # Style of components to generate
 # Valid values: CreateClass | ES6Class | Functional
-componentType: Functional
+componentType: ES6Class
 |]

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -30,7 +30,7 @@ instance ToJSON ProjectType
 instance FromJSON ProjectType
 
 data ComponentType = ES6Class | CreateClass | Functional
-  deriving (Generic, Show, Eq, Ord)
+  deriving (Generic, Read, Show, Eq, Ord)
 instance ToJSON ComponentType
 instance FromJSON ComponentType
 
@@ -52,6 +52,7 @@ data Settings = Settings
   , _sComponentDir  :: Maybe OSFilePath
   , _sMakeContainer :: Bool
   , _sProjectType   :: ProjectType
+  , _sComponentType :: Maybe ComponentType
   }
   deriving (Eq, Show, Ord)
 makeLenses ''Settings
@@ -69,9 +70,13 @@ instance Arbitrary Settings where
     <*> fmap Just genFilePath
     <*> arbitrary
     <*> arbitrary
+    <*> fmap Just arbitrary
 
 instance Arbitrary ProjectType where
   arbitrary = elements [React, ReactNative]
+
+instance Arbitrary ComponentType where
+  arbitrary = elements [ES6Class, CreateClass, Functional]
 
 {--| Generate a filepath using characters 0-9 and A-z --}
 genFilePath :: Gen OSFilePath

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -36,7 +36,7 @@ qcProps = testGroup "(checked by QuickCheck)"
   ]
 
 prop_makesFiles :: Settings -> Property
-prop_makesFiles settings@(Settings componentName (Just componentPath) _container native) = monadicIO $ do
+prop_makesFiles settings@(Settings componentName (Just componentPath) _container native _component) = monadicIO $ do
   let tmpDir = pure $ "/tmp" </> componentPath
   let componentNamePath = fromText componentName
   let tmpSettings = sComponentDir .~  tmpDir $ settings
@@ -55,7 +55,7 @@ prop_makesFiles settings@(Settings componentName (Just componentPath) _container
   assert $ and filesExist
 
 prop_replacePlaceholderText :: Settings -> Property
-prop_replacePlaceholderText settings@(Settings componentName (Just componentPath) _container _native) = monadicIO $ do
+prop_replacePlaceholderText settings@(Settings componentName (Just componentPath) _container _native _component) = monadicIO $ do
   let tmpDir = pure $ "/tmp" </> componentPath
   let componentNamePath = fromText componentName
 


### PR DESCRIPTION
Generate one of the three types of components by passing command line
flag -t or settings the default in the config file.

Still threading a lot of Just/fromJust. Refactor opportunity.

Fixes #15 (`componentType`)