### PR TITLE
Add types cli parser for PropTypes

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,25 +1,43 @@
 * React Component Generator
   [[https://travis-ci.org/tpoulsen/generate-component][https://travis-ci.org/tpoulsen/generate-component.svg?branch=master]]
 
+** Contents
+
+  + [[#installation][Installation]]
+  + [[#usage][Usage]]
+  + [[#commands][Commands]]
+    + [[#init][Init]]
+    + [[#gen][Gen]]
+      + [[#project-type][Project Type]]
+      + [[#redux][Redux]]
+      + [[#component-types][Component Types]]
+      + [[#proptypes][PropTypes]]
+  + [[#examples][Examples]]
+
 ** Installation
    You should have [[https://www.haskell.org/ghc/][GHC]] and [[https://www.haskell.org/cabal/][cabal]] or [[https://docs.haskellstack.org/en/stable/README/][stack]] installed.
 
    Installing `generate-component` is easiest with stack:
    #+BEGIN_SRC sh
+   git clone git@github.com:tpoulsen/generate-component.git
    stack install
    #+END_SRC
 
-   This compiles the program and puts the executable in ~/.local/bin~. If this is in your path, you now have the command `generate-component`.
+   This compiles the program and puts the executable in ~/.local/bin~. If this is in your path, you now have the command ~generate-component~.
 
 ** Usage
+   You can learn about the available command line options with ~generate-component --help~ (or ~-h~).
+
    #+BEGIN_SRC sh
      stack install
      # ... Output omitted for brevity ... #
      Copied executables to $HOME/.local/bin:
      - generate-component
 
-     generate-component -h
-     Flexible generator for React/React-Native components
+     generate-component --help
+     Flexible generator for React/React-Native components. Generate ES6 class,
+     React.createClass, and functional components with optional proptypes and redux
+     containers.
 
      Usage: generate-component COMMAND
      Generate React/React-Native components
@@ -41,19 +59,49 @@
 *** ~gen~
     Generates a component:
     #+BEGIN_SRC sh
-      generate-component gen -h
-
+      $ generate-component gen --help
       Usage: generate-component gen NAME [-d|--component-directory DIR]
-                                    [-r|--redux-container] [-n|--react-native]
-                                    [-t|--component-type ARG]
-        Generate a component
+      [-r|--redux-container] [-n|--react-native]
+      [-t|--component-type ARG] [-p|--proptypes ARG]
+      Generate a component
 
+      Available options:
+      -d,--component-directory DIR
+      Directory in which to add the component. Relative to
+      the project root.
+      -r,--redux-container     Create a redux connected container component
+      -n,--react-native        Create a React Native component
+      -t,--component-type ARG  The type of component to generate. Valid options:
+                               ES6Class | CreateClass | Functional
+      -p,--proptypes ARG       Component props and types (enclosed in quotes) - e.g.
+                               -p "id:number name:string.isRequired"
+      -h,--help                Show this help text
     #+END_SRC
     Command line arguments supersede config file settings.
 
+**** Project Type
+     ~React | ReactNative~
+     This can be set in the config file, ~.generate-component.yaml~.
+     If ~-n~ is provided as a command line option, the config will be overridden and native files will be generated.
+
+**** Redux
+     If the ~-r~ option is provided, a Redux connected container component will be generated.
+
+**** Component Types
+     ~ES6Class | CreateClass | Functional~
+     This can be set in the config file as the default type of component to generate.
+     If ~-t~ and a valid type (e.g. ~-t ES6Class~) are provided on the command line, the provided type will be generated.
+
+**** PropTypes
+     PropTypes can be provided in the command line with the ~-p~ flag.
+     Providing them will pre-fill the `propTypes` declaration in the generated files and the parameters to a functional components.
+     They must be provided as colon separated ~name:propType~ values in a string, e.g:
+     ~-p "name:string id:number age:number"
+
+** Examples
 *** Generating a React component:
    #+BEGIN_SRC sh
-     ~/.local/bin/generate-component Test
+     generate-component Test
      Making directory at: ./app/components/Test
      Copying files...
      Writing ./app/components/Test/Test.js...
@@ -64,7 +112,7 @@
 
 *** Generating a React component in an arbitrary directory:
    #+BEGIN_SRC sh
-     ~/.local/bin/generate-component -d dir Test
+     generate-component -d dir Test
      Making directory at: dir/Test
      Copying files...
      Writing dir/Test/Test.js...
@@ -74,7 +122,7 @@
 
 *** Generating a React Native component:
    #+BEGIN_SRC sh
-     ~/.local/bin/generate-component -n Test
+     generate-component -n Test
      Making directory at: ./app/components/Test
      Copying files...
      Writing ./app/components/Test/Test.js...
@@ -85,7 +133,7 @@
 
 *** Generating a component with a Redux container (works for React and React Native components):
    #+BEGIN_SRC sh
-     ~/.local/bin/generate-component -c Test
+     generate-component -c Test
      Making directory at: ./app/components/Test
      Copying files...
      Writing ./app/components/Test/TestContainer.js...
@@ -97,13 +145,10 @@
 
 *** Attempting to generate a component that already exists:
    #+BEGIN_SRC sh
-     ~/.local/bin/generate-component Test
+     generate-component Test
      Component directory exists; exiting without action.
      Done
    #+END_SRC
-*** Note
-   - DIR: an optional directory under which to create the component; defaults to ~./app/components/~
-   - ~-r~: a flag that, if present, additionally generates a redux container component
 ** Testing
 *** To run the tests:
     #+BEGIN_SRC sh

--- a/src/ComponentGenerator.hs
+++ b/src/ComponentGenerator.hs
@@ -35,7 +35,12 @@ generateDesiredTemplates _ = echo "Bad component path..."
 {--| Determines which templates to create based on command line arguments. --}
 determineTemplatesToGenerate :: Settings -> [Template]
 determineTemplatesToGenerate settings =
-  templatesToGenerate (settings ^. sProjectType) (fromJust $ settings ^. sComponentType) (settings ^. sMakeContainer)
+  templatesToGenerate pType cType propTypes makeContainer
+  where pType         = settings ^. sProjectType
+        cType         = fromJust $ settings ^. sComponentType
+        makeContainer = settings ^. sMakeContainer
+        propTypes     = settings ^. sPropTypes
+
 
 {--| Generates the component's path, writes the file, and replaces the placeholder text with the template name. --}
 generateComponent :: Settings -> Template -> IO OSFilePath

--- a/src/ComponentGenerator.hs
+++ b/src/ComponentGenerator.hs
@@ -16,7 +16,7 @@ import           Types
 
 {--| If the component doesn't already exist, creates component directory and requisite files. --}
 generateDesiredTemplates :: Settings -> IO ()
-generateDesiredTemplates settings@(Settings componentName (Just componentPath') _container _native _type) = do
+generateDesiredTemplates settings@(Settings componentName (Just componentPath') _ _ _ _) = do
   let componentPath = componentPath' </> componentNamePath
   let settings' = settings & sComponentDir .~ Just componentPath
   let componentGenerator = generateComponent settings'

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -3,16 +3,23 @@
 module Parser where
 
 import           Data.Monoid               ((<>))
-import           Data.Text                 (pack)
+import           Data.Text                 (pack, split, words)
 import           Filesystem.Path.CurrentOS (fromText)
 import           Options.Applicative
+import           Prelude                   hiding (words)
 import           Types
 
 {--| Command line argument parser --}
+opts :: ParserInfo Command
+opts = info (commandParser <**> helper)
+  ( fullDesc
+  <> progDesc "Generate React/React-Native components"
+  <> header "Flexible generator for React/React-Native components" )
+
 commandParser :: Parser Command
 commandParser = subparser $
-     command "init" (info initParser $ progDesc "Create a config file")
-  <> command "gen" (info settingsParser $ progDesc "Generate a component")
+     command "init" (info (initParser <**> helper) $ progDesc "Create a config file")
+  <> command "gen" (info (settingsParser <**> helper) $ progDesc "Generate a component")
 
 initParser :: Parser Command
 initParser = pure Init
@@ -30,6 +37,7 @@ settingsParser = fmap Generate $ Settings <$>
        <> short 'n'
        <> help "Create a React Native component" )
       <*> parseComponentType
+      <*> parsePropTypes
 
 parseComponentDirectory :: Parser OSFilePath
 parseComponentDirectory =
@@ -46,8 +54,14 @@ parseComponentType =
   <> short 't'
   <> help "The type of component to generate" )
 
-opts :: ParserInfo Command
-opts = info (commandParser <**> helper)
-  ( fullDesc
-  <> progDesc "Generate React/React-Native components"
-  <> header "Flexible generator for React/React-Native components" )
+parsePropTypes :: Parser (Maybe [PropType])
+parsePropTypes =
+  optional $ option parsePropTypesReader
+  ( long "proptypes"
+  <> short 'p'
+  <> help "Component props and types (enclosed in quotes) - e.g. -p \"id:number name:string\"" )
+
+parsePropTypesReader :: ReadM [PropType]
+parsePropTypesReader = eitherReader $ \s ->
+  pure $ toPropType $ split (== ':') <$> (words . pack $ s)
+  where toPropType = fmap (\x -> PropType (Prelude.head x) (Prelude.last x))

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -14,7 +14,7 @@ opts :: ParserInfo Command
 opts = info (commandParser <**> helper)
   ( fullDesc
   <> progDesc "Generate React/React-Native components"
-  <> header "Flexible generator for React/React-Native components" )
+  <> header "Flexible generator for React/React-Native components. Generate ES6 class, React.createClass, and functional components with optional proptypes and redux containers." )
 
 commandParser :: Parser Command
 commandParser = subparser $
@@ -52,7 +52,7 @@ parseComponentType =
   optional $ option auto
   ( long "component-type"
   <> short 't'
-  <> help "The type of component to generate" )
+  <> help "The type of component to generate. Valid options: ES6Class | CreateClass | Functional" )
 
 parsePropTypes :: Parser (Maybe [PropType])
 parsePropTypes =

--- a/src/Templates.hs
+++ b/src/Templates.hs
@@ -7,23 +7,23 @@ import           Templates.Containers
 import           Templates.Styles
 import           Types
 
-templatesToGenerate :: ProjectType -> ComponentType -> Bool -> [Template]
-templatesToGenerate p c container =
+templatesToGenerate :: ProjectType -> ComponentType -> Maybe [PropType] -> Bool -> [Template]
+templatesToGenerate p c propTypes container =
   if container
     then containerTemplate : containerIndexTemplate : componentTemplates
     else indexTemplate : componentTemplates
-  where componentTemplates = pickComponentTemplates p c
+  where componentTemplates = pickComponentTemplates p c propTypes
 
-pickComponentTemplates :: ProjectType -> ComponentType -> [Template]
-pickComponentTemplates p c =
+pickComponentTemplates :: ProjectType -> ComponentType -> Maybe [PropType] -> [Template]
+pickComponentTemplates p c propTypes =
   case p of
-    ReactNative -> nativeTemplates c
-    React       -> reactTemplates c
+    ReactNative -> nativeTemplates c propTypes
+    React       -> reactTemplates c propTypes
 
-nativeTemplates :: ComponentType -> [Template]
-nativeTemplates c =
-  [nativeComponentTemplate c, stylesTemplate]
+nativeTemplates :: ComponentType -> Maybe [PropType] -> [Template]
+nativeTemplates c propTypes =
+  [nativeComponentTemplate c propTypes, stylesTemplate]
 
-reactTemplates :: ComponentType -> [Template]
-reactTemplates c =
-  [reactComponentTemplate c]
+reactTemplates :: ComponentType -> Maybe [PropType] -> [Template]
+reactTemplates c propTypes =
+  [reactComponentTemplate c propTypes]

--- a/src/Templates/Components.hs
+++ b/src/Templates/Components.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE QuasiQuotes       #-}
 module Templates.Components where
 
+import           Control.Lens                  ((^.))
 import           Data.Monoid                   ((<>))
 import           Data.Text                     (Text, intercalate, pack)
 import           Text.InterpolatedString.Perl6 (q)
@@ -18,5 +19,11 @@ stringifyPropTypes :: Int -> Maybe [PropType] -> Text
 stringifyPropTypes nSpaces ts =
   case ts of
     Nothing -> ""
-    Just x  -> intercalate (",\n" <> spaces) $ pack . show <$> x
+    Just xs -> intercalate (",\n" <> spaces) $ pack . show <$> xs
   where spaces = pack . take nSpaces $ cycle " "
+
+propNames :: Maybe [PropType] -> Text
+propNames ts =
+  case ts of
+    Nothing -> ""
+    Just xs -> intercalate ", " $ fmap (^. name) xs

--- a/src/Templates/Components.hs
+++ b/src/Templates/Components.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE QuasiQuotes       #-}
 module Templates.Components where
 
-import           Text.InterpolatedString.Perl6 (q, qc)
+import           Data.Monoid                   ((<>))
+import           Data.Text                     (Text, intercalate, pack)
+import           Text.InterpolatedString.Perl6 (q)
 import           Types
 
 indexTemplate :: Template
@@ -11,3 +13,10 @@ import COMPONENT from './COMPONENT';
 
 export default COMPONENT;
 |]
+
+stringifyPropTypes :: Int -> Maybe [PropType] -> Text
+stringifyPropTypes nSpaces ts =
+  case ts of
+    Nothing -> ""
+    Just x  -> intercalate (",\n" <> spaces) $ pack . show <$> x
+  where spaces = pack . take nSpaces $ cycle " "

--- a/src/Templates/Components/React.hs
+++ b/src/Templates/Components/React.hs
@@ -2,18 +2,19 @@
 {-# LANGUAGE QuasiQuotes       #-}
 module Templates.Components.React where
 
+import           Templates.Components
 import           Text.InterpolatedString.Perl6 (q, qc)
 import           Types
 
-reactComponentTemplate :: ComponentType -> Template
-reactComponentTemplate cType =
+reactComponentTemplate :: ComponentType -> Maybe [PropType] -> Template
+reactComponentTemplate cType propTypes =
   case cType of
-    Functional  -> functionalReactComponent
-    ES6Class    -> es6ReactComponent
-    CreateClass -> createClassReactComponent
+    Functional  -> functionalReactComponent propTypes
+    ES6Class    -> es6ReactComponent propTypes
+    CreateClass -> createClassReactComponent propTypes
 
-functionalReactComponent :: Template
-functionalReactComponent = Template "COMPONENT.js" [q|
+functionalReactComponent :: Maybe [PropType] -> Template
+functionalReactComponent p = Template "COMPONENT.js" [qc|
 // @flow
 /*
    NOTE: This file was auto-generated for a component
@@ -23,21 +24,22 @@ functionalReactComponent = Template "COMPONENT.js" [q|
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {render} from 'react-dom';
+import \{render} from 'react-dom';
 
-const COMPONENT = ({}) => (
+const COMPONENT = (\{}) => (
   <div>
   </div>
 );
 
-COMPONENT.propTypes = {
+COMPONENT.propTypes = \{
+  {stringifyPropTypes 2 p}
 };
 
 export default COMPONENT;
 |]
 
-es6ReactComponent :: Template
-es6ReactComponent = Template "COMPONENT.js" [q|
+es6ReactComponent :: Maybe [PropType] -> Template
+es6ReactComponent p = Template "COMPONENT.js" [qc|
 // @flow
 /*
    NOTE: This file was auto-generated for a component
@@ -45,15 +47,16 @@ es6ReactComponent = Template "COMPONENT.js" [q|
    needed to be useful.
 */
 
-import React, {Component} from 'react';
+import React, \{Component} from 'react';
 import PropTypes from 'prop-types';
-import {render} from 'react-dom';
+import \{render} from 'react-dom';
 
-class COMPONENT extends Component {
-  static propTypes = {
+class COMPONENT extends Component \{
+  static propTypes = \{
+    {stringifyPropTypes 4 p}
   };
 
-  render() {
+  render() \{
     return (
       <div>
       </div>
@@ -64,8 +67,8 @@ class COMPONENT extends Component {
 export default COMPONENT;
 |]
 
-createClassReactComponent :: Template
-createClassReactComponent = Template "COMPONENT.js" [q|
+createClassReactComponent :: Maybe [PropType] -> Template
+createClassReactComponent p = Template "COMPONENT.js" [qc|
 // @flow
 /*
    NOTE: This file was auto-generated for a component
@@ -73,16 +76,17 @@ createClassReactComponent = Template "COMPONENT.js" [q|
    needed to be useful.
 */
 
-import React, {Component} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
-import {render} from 'react-dom';
+import \{render} from 'react-dom';
 
-const COMPONENT = createReactClass({
-  propTypes: {
+const COMPONENT = createReactClass(\{
+  propTypes: \{
+    {stringifyPropTypes 4 p}
   };
 
-  render() {
+  render() \{
     return (
       <div>
       </div>

--- a/src/Templates/Components/React.hs
+++ b/src/Templates/Components/React.hs
@@ -26,7 +26,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import \{render} from 'react-dom';
 
-const COMPONENT = (\{}) => (
+const COMPONENT = (\{{propNames p}}) => (
   <div>
   </div>
 );

--- a/src/Templates/Components/ReactNative.hs
+++ b/src/Templates/Components/ReactNative.hs
@@ -28,7 +28,7 @@ import \{View} from 'react-native';
 
 import styles from './styles';
 
-const COMPONENT = (\{}) => (
+const COMPONENT = (\{{propNames p}}) => (
   <View>
   </View>
 );

--- a/src/Templates/Components/ReactNative.hs
+++ b/src/Templates/Components/ReactNative.hs
@@ -2,18 +2,19 @@
 {-# LANGUAGE QuasiQuotes       #-}
 module Templates.Components.ReactNative where
 
+import           Templates.Components
 import           Text.InterpolatedString.Perl6 (q, qc)
 import           Types
 
-nativeComponentTemplate :: ComponentType -> Template
-nativeComponentTemplate cType =
+nativeComponentTemplate :: ComponentType -> Maybe [PropType] -> Template
+nativeComponentTemplate cType propTypes =
   case cType of
-    Functional  -> functionalNativeComponent
-    ES6Class    -> es6NativeComponent
-    CreateClass -> createClassNativeComponent
+    Functional  -> functionalNativeComponent propTypes
+    ES6Class    -> es6NativeComponent propTypes
+    CreateClass -> createClassNativeComponent propTypes
 
-functionalNativeComponent :: Template
-functionalNativeComponent = Template "COMPONENT.js" [q|
+functionalNativeComponent :: Maybe [PropType] -> Template
+functionalNativeComponent p = Template "COMPONENT.js" [qc|
 // @flow
 /*
    NOTE: This file was auto-generated for a component
@@ -23,23 +24,24 @@ functionalNativeComponent = Template "COMPONENT.js" [q|
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {View} from 'react-native';
+import \{View} from 'react-native';
 
 import styles from './styles';
 
-const COMPONENT = ({}) => (
+const COMPONENT = (\{}) => (
   <View>
   </View>
 );
 
-COMPONENT.propTypes = {
+COMPONENT.propTypes = \{
+  {stringifyPropTypes 2 p}
 };
 
 export default COMPONENT;
 |]
 
-es6NativeComponent :: Template
-es6NativeComponent = Template "COMPONENT.js" [q|
+es6NativeComponent :: Maybe [PropType] -> Template
+es6NativeComponent p = Template "COMPONENT.js" [qc|
 // @flow
 /*
    NOTE: This file was auto-generated for a component
@@ -49,15 +51,16 @@ es6NativeComponent = Template "COMPONENT.js" [q|
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {View} from 'react-native';
+import \{View} from 'react-native';
 
 import styles from './styles';
 
-class COMPONENT extends Component {
-  static propTypes = {
+class COMPONENT extends Component \{
+  static propTypes = \{
+    {stringifyPropTypes 4 p}
   };
 
-  render() {
+  render() \{
     return (
       <View>
       </View>
@@ -68,8 +71,8 @@ class COMPONENT extends Component {
 export default COMPONENT;
 |]
 
-createClassNativeComponent :: Template
-createClassNativeComponent = Template "COMPONENT.js" [q|
+createClassNativeComponent :: Maybe [PropType] -> Template
+createClassNativeComponent p = Template "COMPONENT.js" [qc|
 // @flow
 /*
    NOTE: This file was auto-generated for a component
@@ -77,16 +80,17 @@ createClassNativeComponent = Template "COMPONENT.js" [q|
    needed to be useful.
 */
 
-import React, {Component} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
-import {View} from 'react-native';
+import \{View} from 'react-native';
 
-const COMPONENT = createReactClass({
-  propTypes: {
+const COMPONENT = createReactClass(\{
+  propTypes: \{
+    {stringifyPropTypes 4 p}
   };
 
-  render() {
+  render() \{
     return (
       <View>
       </View>

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -34,6 +34,11 @@ data ComponentType = ES6Class | CreateClass | Functional
 instance ToJSON ComponentType
 instance FromJSON ComponentType
 
+data PropType = PropType
+  { name     :: Text
+  , propType :: Text
+  } deriving (Generic, Show, Eq, Ord)
+
 data Config = Config
   { _projectType      :: ProjectType
   , _componentType    :: ComponentType
@@ -46,13 +51,13 @@ instance FromJSON Config where
     <*> v .: "componentType"
     <*> v .: "defaultDirectory"
 
-
 data Settings = Settings
   { _sComponentName :: Text
   , _sComponentDir  :: Maybe OSFilePath
   , _sMakeContainer :: Bool
   , _sProjectType   :: ProjectType
   , _sComponentType :: Maybe ComponentType
+  , _sPropTypes     :: Maybe [PropType]
   }
   deriving (Eq, Show, Ord)
 makeLenses ''Settings
@@ -71,12 +76,18 @@ instance Arbitrary Settings where
     <*> arbitrary
     <*> arbitrary
     <*> fmap Just arbitrary
+    <*> arbitrary
 
 instance Arbitrary ProjectType where
   arbitrary = elements [React, ReactNative]
 
 instance Arbitrary ComponentType where
   arbitrary = elements [ES6Class, CreateClass, Functional]
+
+instance Arbitrary PropType where
+  arbitrary = PropType <$>
+        genText
+    <*> genText
 
 {--| Generate a filepath using characters 0-9 and A-z --}
 genFilePath :: Gen OSFilePath

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -36,12 +36,13 @@ instance ToJSON ComponentType
 instance FromJSON ComponentType
 
 data PropType = PropType
-  { name     :: Text
-  , propType :: Text
+  { _name     :: Text
+  , _propType :: Text
   } deriving (Generic, Eq, Ord)
 instance Show PropType where
   show (PropType n t) =
     unpack $ n <> ": PropTypes." <> t
+makeLenses ''PropType
 
 data Config = Config
   { _projectType      :: ProjectType

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -7,6 +7,7 @@ module Types where
 import           Control.Lens              hiding (elements)
 import           Data.Aeson                (decode, withObject)
 import           Data.Char                 (chr)
+import           Data.Monoid               ((<>))
 import           Data.Text
 import           Data.Yaml                 (FromJSON, ToJSON, parseJSON, (.:))
 import           Filesystem.Path.CurrentOS (FilePath, fromText, valid)
@@ -37,7 +38,10 @@ instance FromJSON ComponentType
 data PropType = PropType
   { name     :: Text
   , propType :: Text
-  } deriving (Generic, Show, Eq, Ord)
+  } deriving (Generic, Eq, Ord)
+instance Show PropType where
+  show (PropType n t) =
+    unpack $ n <> ": PropTypes." <> t
 
 data Config = Config
   { _projectType      :: ProjectType

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -36,7 +36,7 @@ qcProps = testGroup "(checked by QuickCheck)"
   ]
 
 prop_makesFiles :: Settings -> Property
-prop_makesFiles settings@(Settings componentName (Just componentPath) _container native _component) = monadicIO $ do
+prop_makesFiles settings@(Settings componentName (Just componentPath) _ native _ _) = monadicIO $ do
   let tmpDir = pure $ "/tmp" </> componentPath
   let componentNamePath = fromText componentName
   let tmpSettings = sComponentDir .~  tmpDir $ settings
@@ -55,7 +55,7 @@ prop_makesFiles settings@(Settings componentName (Just componentPath) _container
   assert $ and filesExist
 
 prop_replacePlaceholderText :: Settings -> Property
-prop_replacePlaceholderText settings@(Settings componentName (Just componentPath) _container _native _component) = monadicIO $ do
+prop_replacePlaceholderText settings@(Settings componentName (Just componentPath) _ _ _ _) = monadicIO $ do
   let tmpDir = pure $ "/tmp" </> componentPath
   let componentNamePath = fromText componentName
 


### PR DESCRIPTION
To allow the user to supply proptypes as quoted, colon separated
name:type pairs, e.g:

`-p "name:string age:number"`