### PR TITLE
Improve config file generation & parse failure handling

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -4,7 +4,7 @@ module Config where
 
 import           Control.Lens              ((&), (.~), (^.))
 import           Data.Yaml                 (ParseException, decodeFileEither)
-import           Filesystem.Path.CurrentOS (encodeString, fromText, parent,
+import           Filesystem.Path.CurrentOS (encodeString, fromText, parent, toText,
                                             (</>))
 import           Turtle.Prelude
 import           Types
@@ -19,7 +19,7 @@ projectRoot =
 {-| A React project must have a node_modules directory. |-}
 findProjectRoot :: IO OSFilePath -> IO OSFilePath
 findProjectRoot dir = do
-  isRoot <- hasNodeModules =<< dir
+  isRoot <- hasConfigFile =<< dir
   if isRoot
   then dir
   else findProjectRoot $ recurseUp =<< dir
@@ -28,18 +28,25 @@ recurseUp :: OSFilePath -> IO OSFilePath
 recurseUp dir =
   return $ parent dir
 
-hasNodeModules :: OSFilePath -> IO Bool
-hasNodeModules dir =
-  testdir $ dir </> "node_modules"
+hasConfigFile :: OSFilePath -> IO Bool
+hasConfigFile dir =
+  testfile $ dir </> ".generate-component.yaml"
 
-readConfig :: IO (Either ParseException Config)
+readConfig :: IO Config
 readConfig = do
   rootDir <- projectRoot
   let configPath = rootDir </> ".generate-component.yaml" :: OSFilePath
-  decodeFileEither $ encodeString configPath
+  let configContents = decodeFileEither $ encodeString configPath
+  configFromEither =<< configContents
 
-mergeConfig :: Either ParseException Config -> Settings -> Settings
-mergeConfig (Right c) s =
+configFromEither :: Either ParseException Config -> IO Config
+configFromEither c =
+  case c of
+    Left _e -> defaultConfig
+    Right config -> return config
+
+mergeConfig :: Config -> Settings -> Settings
+mergeConfig c s =
   s & sProjectType .~ (c ^. projectType)
     & sComponentDir .~ dir
     & sComponentType .~ cType
@@ -50,4 +57,10 @@ mergeConfig (Right c) s =
     cType = case s ^. sComponentType of
       Nothing -> Just $ c ^. componentType
       Just ct -> Just ct
-mergeConfig _ s = s
+
+defaultConfig :: IO Config
+defaultConfig = do
+  d <- pwd
+  let dir = toText d
+  let buildConfig = Config React ES6Class
+  return $ either buildConfig buildConfig dir

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -32,7 +32,7 @@ filePathToText = pack . encodeString
 
 initializeWithConfigFile :: IO ()
 initializeWithConfigFile = do
-  appRoot <- projectRoot
+  appRoot <- pwd
   let configLocation = appRoot </> (fromText . filename $ configTemplate)
   dirExists <- testfile configLocation
   if dirExists

--- a/src/Templates/Config.hs
+++ b/src/Templates/Config.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE QuasiQuotes       #-}
 module Templates.Config where
 
-import           Text.InterpolatedString.Perl6 (q, qc)
+import           Text.InterpolatedString.Perl6 (q)
 import           Types
 
 configTemplate :: Template


### PR DESCRIPTION
Config file is now generated in the directory that `generate-component
init` is called from; no longer attempts to find a project's root
directory. This puts onus on the user to put the config file in a sane
location.

If there's a parse failure for the config file, a default config is
used. This is still replaced with command line arguments if they are
provided.

Fixes #26 