### PR TITLE
Improve proptype parser error messages

### DIFF
--- a/componentGenerator.cabal
+++ b/componentGenerator.cabal
@@ -24,6 +24,7 @@ executable generate-component
                      , Config
                      , Parser
                      , Parser.PropType
+                     , Paths_componentGenerator
                      , Templates
                      , Templates.Config
                      , Templates.Components

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -9,9 +9,11 @@ import           Config
 import           Control.Lens              (over)
 import           Data.Monoid               ((<>))
 import           Data.Text                 (Text, pack)
+import           Data.Version              (showVersion)
 import           Filesystem.Path.CurrentOS (encodeString, fromText, (</>))
 import           Options.Applicative       (execParser)
 import           Parser
+import           Paths_componentGenerator  (version)
 import           Templates.Config
 import           Turtle.Prelude
 import           Types
@@ -21,6 +23,7 @@ main = do
   command <- execParser opts
   case command of
     Init -> initializeWithConfigFile
+    Version -> putStrLn ("generate-component v" <> showVersion version)
     Generate settings -> do
       configFile <- readConfig
       appRoot <- projectRoot

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -22,9 +22,13 @@ commandParser :: Parser Command
 commandParser = subparser $
      command "init" (info (initParser <**> helper) $ progDesc "Create a config file")
   <> command "gen" (info (settingsParser <**> helper) $ progDesc "Generate a component")
+  <> command "version" (info (versionParser <**> helper) $ progDesc "generate-component version")
 
 initParser :: Parser Command
 initParser = pure Init
+
+versionParser :: Parser Command
+versionParser = pure Version
 
 settingsParser :: Parser Command
 settingsParser = fmap Generate $ Settings <$>

--- a/src/Parser/PropType.hs
+++ b/src/Parser/PropType.hs
@@ -4,13 +4,16 @@ module Parser.PropType where
 
 import           Control.Applicative
 import qualified Data.Attoparsec.Text as A
-import           Data.Text            (Text, pack)
+import           Data.Text            (pack)
 import           Options.Applicative
-import           Types
+--import           Types
 import           Types.PropTypes
 
 optparseProps :: ReadM [Prop]
-optparseProps = eitherReader (A.parseOnly (parseCLIPropTypes <* A.endOfInput) . pack)
+optparseProps = eitherReader $ \inp -> case runPropsParser inp of
+  Left _ -> Left "Unable to parse PropTypes;\n\t\tPlease see https://github.com/tpoulsen/generate-component#props for valid PropType values."
+  Right props -> Right props
+  where runPropsParser = A.parseOnly (parseCLIPropTypes <* A.endOfInput) . pack
 
 parseCLIPropTypes :: A.Parser [Prop]
 parseCLIPropTypes = parseProp `A.sepBy1'` A.space
@@ -33,7 +36,7 @@ maybeParser p = A.option Nothing (Just <$> p)
 
 parseRequiredStatus :: A.Parser IsRequired
 parseRequiredStatus = do
-  requiredStatus <- A.string ".isRequired"
+  _requiredStatus <- A.string ".isRequired"
   return Required
 
 parsePropType :: A.Parser PropType

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -62,6 +62,7 @@ type CSettings = Settings
 
 data Command =
     Init
+  | Version
   | Generate CSettings
 
 {--| Testing --}


### PR DESCRIPTION
- Catches the parse failure and replaces the error message with one directing the user to check the readme for valid proptypes.

- Adds `version` command

Closes #27 
Closes #28 