### PR TITLE
Add template generation for Reason components

### DIFF
--- a/README.org
+++ b/README.org
@@ -93,7 +93,7 @@ A generated config file looks like this:
   defaultDirectory: app/components
 
   # Style of components to generate
-  # Valid values: CreateClass | ES6Class | Functional
+  # Valid values: CreateClass | ES6Class | Functional | Reason
   componentType: ES6Class
 #+END_SRC
 *** ~version~
@@ -114,7 +114,7 @@ Generates a component:
       -r,--redux-container     Create a redux connected container component
       -n,--react-native        Create a React Native component
       -t,--component-type ARG  The type of component to generate. Valid options:
-                               ES6Class | CreateClass | Functional
+                               ES6Class | CreateClass | Functional | Reason
       -p,--proptypes ARG       Component props and types (enclosed in quotes) - e.g.
                                -p "id:number name:string.isRequired"
       -h,--help                Show this help text
@@ -132,7 +132,7 @@ If ~-n~ is provided as a command line option, the config will be overridden and 
 If the ~-r~ option is provided, a Redux connected container component will be generated.
 
 **** Component Types
-~ES6Class | CreateClass | Functional~
+~ES6Class | CreateClass | Functional | Reason~
 This can be set in the config file as the default type of component to generate.
 If ~-t~ and a valid type (e.g. ~-t ES6Class~) are provided on the command line, the provided type will be generated.
 

--- a/componentGenerator.cabal
+++ b/componentGenerator.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                componentGenerator
-version:             0.4.3
+version:             0.5.0
 synopsis:            Generate scaffolds for React components.
 description:         A generator for React and React Rative components.
 license:             BSD3

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -58,7 +58,7 @@ parseComponentType =
   optional $ option auto
   ( long "component-type"
   <> short 't'
-  <> help "The type of component to generate. Valid options: ES6Class | CreateClass | Functional" )
+  <> help "The type of component to generate. Valid options: ES6Class | CreateClass | Functional | Reason" )
 
 parsePropTypes :: Parser (Maybe [Prop])
 parsePropTypes =

--- a/src/Templates.hs
+++ b/src/Templates.hs
@@ -12,7 +12,7 @@ templatesToGenerate :: ProjectType -> ComponentType -> Maybe [Prop] -> Bool -> [
 templatesToGenerate p c propTypes container =
   if container
     then containerTemplate : containerIndexTemplate : componentTemplates
-    else indexTemplate : componentTemplates
+    else if c == Reason then componentTemplates else indexTemplate : componentTemplates
   where componentTemplates = pickComponentTemplates p c propTypes
 
 pickComponentTemplates :: ProjectType -> ComponentType -> Maybe [Prop] -> [Template]

--- a/src/Templates/Components.hs
+++ b/src/Templates/Components.hs
@@ -28,3 +28,15 @@ propNames ts =
   case ts of
     Nothing -> ""
     Just xs -> intercalate ", " $ fmap (^. name) xs
+
+reasonProps :: Maybe [Prop] -> Text
+reasonProps ts =
+  case ts of
+    Nothing -> ""
+    Just xs -> intercalate " " $ fmap (\x -> ("##" <>) $ (^. name) x) xs
+
+reasonJSProps :: Maybe [Prop] -> Text
+reasonJSProps ts =
+  case ts of
+    Nothing -> ""
+    Just xs -> intercalate " " $ fmap (\x -> (\y -> y <> "::jsProps##" <> y) $ (^. name) x) xs

--- a/src/Templates/Components/React.hs
+++ b/src/Templates/Components/React.hs
@@ -3,6 +3,7 @@
 
 module Templates.Components.React where
 
+import           Data.Text                     (Text)
 import           Templates.Components
 import           Text.InterpolatedString.Perl6 (qc)
 import           Types
@@ -14,6 +15,7 @@ reactComponentTemplate cType propTypes =
     Functional  -> functionalReactComponent propTypes
     ES6Class    -> es6ReactComponent propTypes
     CreateClass -> createClassReactComponent propTypes
+    Reason      -> reasonComponent propTypes
 
 functionalReactComponent :: Maybe [Prop] -> Template
 functionalReactComponent p = Template "COMPONENT.js" [qc|// @flow
@@ -92,3 +94,23 @@ const COMPONENT = createReactClass(\{
 
 export default COMPONENT;
 |]
+
+reasonComponent :: Maybe [Prop] -> Template
+reasonComponent p = Template "COMPONENT.re" [qc|/* COMPONENT.re */
+let component = ReasonReact.statelessComponent "COMPONENT";
+
+let se = ReasonReact.stringToElement;
+
+let make {reasonProps p} _children => \{
+  ...component,
+  render: fun _self =>
+    <div> </div>
+};
+
+/* This wrapper allows you to call React.createElement from JS and pass in props */
+let comp =
+  ReasonReact.wrapReasonForJs
+    ::component
+    (fun jsProps => make {reasonJSProps p} {ocamlList});
+|]
+  where ocamlList = "[||]" :: Text -- Embedding directly killed the quasiquoter

--- a/src/Templates/Components/ReactNative.hs
+++ b/src/Templates/Components/ReactNative.hs
@@ -3,6 +3,7 @@
 module Templates.Components.ReactNative where
 
 import           Templates.Components
+import           Templates.Components.React    (reasonComponent)
 import           Text.InterpolatedString.Perl6 (qc)
 import           Types
 import           Types.PropTypes
@@ -13,6 +14,7 @@ nativeComponentTemplate cType propTypes =
     Functional  -> functionalNativeComponent propTypes
     ES6Class    -> es6NativeComponent propTypes
     CreateClass -> createClassNativeComponent propTypes
+    Reason      -> reasonNativeComponent propTypes
 
 functionalNativeComponent :: Maybe [Prop] -> Template
 functionalNativeComponent p = Template "COMPONENT.js" [qc|// @flow
@@ -98,3 +100,6 @@ const COMPONENT = createReactClass(\{
 
 export default COMPONENT;
 |]
+
+reasonNativeComponent :: Maybe [Prop] -> Template
+reasonNativeComponent ts = reasonComponent ts

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -30,7 +30,7 @@ data ProjectType = React | ReactNative
 instance ToJSON ProjectType
 instance FromJSON ProjectType
 
-data ComponentType = ES6Class | CreateClass | Functional
+data ComponentType = ES6Class | CreateClass | Functional | Reason
   deriving (Generic, Read, Show, Eq, Ord)
 instance ToJSON ComponentType
 instance FromJSON ComponentType
@@ -79,7 +79,7 @@ instance Arbitrary ProjectType where
   arbitrary = elements [React, ReactNative]
 
 instance Arbitrary ComponentType where
-  arbitrary = elements [ES6Class, CreateClass, Functional]
+  arbitrary = elements [ES6Class, CreateClass, Functional, Reason]
 
 instance Arbitrary Prop where
   arbitrary = Prop <$>

--- a/todo.org
+++ b/todo.org
@@ -1,0 +1,8 @@
+* Running goals and todo-list
+** TODO Refactor prop -> text functions in Components.hs
+   There are now several that are very similar. Can abstract common functionality.
+** TODO Add proper ReactNative template for Reason
+   Currently just reuses the regular React one.
+** TODO Utilize a state monad to stop threading so much state around
+** TODO Refactor templatesToGenerate
+   It's currently messy.


### PR DESCRIPTION
Adds Reason as a component type
Adds a template for Reason components

When componentType == Reason, does not generate an index.
Still to do - add a proper React Native Reason template.