### PR TITLE
Fixes import on es6 component in react native

### DIFF
--- a/src/Templates/Components/ReactNative.hs
+++ b/src/Templates/Components/ReactNative.hs
@@ -50,7 +50,7 @@ es6NativeComponent p = Template "COMPONENT.js" [qc|// @flow
    needed to be useful.
 */
 
-import React from 'react';
+import React, \{Component} from 'react';
 import PropTypes from 'prop-types';
 import \{View} from 'react-native';
 


### PR DESCRIPTION
Easily fixable once the component is generated, however just nice not to have to do that.